### PR TITLE
Allow customizing whether or not to show the dialog for pasting

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "max_image_width": 800,
     "max_image_height": 600,
     "image_quality": 20,
-    "show_settings": "menus",
+    "show_settings": "toolbar",
     "drag_and_drop": true,
     "copy_paste": false,
     "cwebp_args": [

--- a/config.md
+++ b/config.md
@@ -16,8 +16,9 @@
 * `show_context_menu_entry` - Add an entry to the editor context menu.
 * `show_editor_button` - Add a button to the editor toolbar.
 * `show_settings` - When to show the settings dialog.
-    * `always` - Every time you paste a new image.
-    * `menus` - When the toolbar button or the context menu is activated.
+    * `always` - Every time you try to insert a webp image.
+    * `toolbar` - When the toolbar button is clicked.
+    * `paste` - When you paste an image.
     * `drag_and_drop` - On drag-and-drop (if enabled).
     * `never` - Only when you press `Tools > WebP settings`.
 * `filename_pattern_num` - Used internally.

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from typing import Iterable
+from typing import Iterable, Sequence
 
 from .ajt_common.addon_config import AddonConfigManager, set_config_update_action
 from .utils.show_options import ShowOptions
@@ -27,7 +27,7 @@ class PasteImagesAsWebPConfig(AddonConfigManager):
         super().__init__()
         set_config_update_action(self.update_from_addon_manager)
 
-    def show_settings(self) -> list[ShowOptions]:
+    def show_settings(self) -> Sequence[ShowOptions]:
         instances = []
         for name in self['show_settings'].split(','):
             try:

--- a/events.py
+++ b/events.py
@@ -67,7 +67,7 @@ def on_process_mime(
         return convert_mime(mime, editor_web_view.editor, action=ShowOptions.drag_and_drop)
 
     if config["copy_paste"] and not drop_event and (mime.hasImage() or has_local_file(mime)):
-        return convert_mime(mime, editor_web_view.editor, action=ShowOptions.menus)
+        return convert_mime(mime, editor_web_view.editor, action=ShowOptions.paste)
 
     return mime
 

--- a/menus.py
+++ b/menus.py
@@ -51,9 +51,9 @@ def action_tooltip():
     )
 
 
-def insert_webp(editor: Editor):
+def insert_webp(editor: Editor, source: ShowOptions):
     mime: QMimeData = editor.mw.app.clipboard().mimeData()
-    w = OnPasteConverter(editor, editor.note, ShowOptions.menus)
+    w = OnPasteConverter(editor, editor.note, source)
     try:
         w.convert_mime(mime)
         insert_image_html(editor, w.filename)
@@ -65,7 +65,7 @@ def insert_webp(editor: Editor):
 def on_editor_will_show_context_menu(webview: EditorWebView, menu: QMenu):
     if config.get("show_context_menu_entry") is True:
         action: QAction = menu.addAction(action_tooltip())
-        qconnect(action.triggered, lambda _, e=webview.editor: insert_webp(e))
+        qconnect(action.triggered, lambda _, e=webview.editor: insert_webp(e, source=ShowOptions.paste))
 
 
 def on_editor_did_init_buttons(buttons: list[str], editor: Editor):
@@ -76,7 +76,7 @@ def on_editor_did_init_buttons(buttons: list[str], editor: Editor):
         buttons.append(editor.addButton(
             icon=os.path.join(ADDON_PATH, "icons", "webp.png"),
             cmd="ajt__paste_webp_button",
-            func=lambda e=editor: insert_webp(e),
+            func=lambda e=editor: insert_webp(e, source=ShowOptions.toolbar),
             tip=action_tooltip(),
             keys=config['shortcut'] or None,
         ))
@@ -88,7 +88,7 @@ def on_editor_did_init_shortcuts(cuts: list[tuple], self: Editor):
     If editor button is enabled, it has its own keyboard shortcut.
     """
     if config["show_editor_button"] is False and config['shortcut']:
-        cuts.append((config['shortcut'], lambda e=self: insert_webp(e)))
+        cuts.append((config['shortcut'], lambda e=self: insert_webp(e, source=ShowOptions.paste)))
 
 
 def setup_editor_menus():

--- a/utils/show_options.py
+++ b/utils/show_options.py
@@ -10,13 +10,6 @@ class ShowOptions(enum.Enum):
     def __eq__(self, other: str):
         return self.name == other
 
-    @classmethod
-    def index_of(cls, name):
-        for index, item in enumerate(cls):
-            if name == item.name:
-                return index
-        return 0
-
 
 def main():
     print(ShowOptions['menus'])

--- a/utils/show_options.py
+++ b/utils/show_options.py
@@ -2,7 +2,7 @@ import enum
 
 
 class ShowOptions(enum.Enum):
-    menus = "Toolbar and menus"
+    toolbar = "Toolbar"
     drag_and_drop = "On drag and drop"
     add_note = "Note added"
     paste = "On paste"
@@ -12,7 +12,7 @@ class ShowOptions(enum.Enum):
 
 
 def main():
-    print(ShowOptions['menus'])
+    print(ShowOptions['toolbar'])
 
 
 if __name__ == '__main__':

--- a/utils/show_options.py
+++ b/utils/show_options.py
@@ -7,9 +7,6 @@ class ShowOptions(enum.Enum):
     add_note = "Note added"
     paste = "On paste"
 
-    def __eq__(self, other: str):
-        return self.name == other
-
 
 def main():
     print(ShowOptions['toolbar'])

--- a/utils/show_options.py
+++ b/utils/show_options.py
@@ -5,6 +5,7 @@ class ShowOptions(enum.Enum):
     menus = "Toolbar and menus"
     drag_and_drop = "On drag and drop"
     add_note = "Note added"
+    paste = "On paste"
 
     def __eq__(self, other: str):
         return self.name == other

--- a/utils/show_options.py
+++ b/utils/show_options.py
@@ -9,7 +9,7 @@ class ShowOptions(enum.Enum):
 
 
 def main():
-    print(ShowOptions['toolbar'])
+    print(ShowOptions["toolbar"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #28.

This PR split the old `menus` action into two variants: `toolbar` and `paste`. It allows the user to customize whether or not to show the dialog one paste independently. This is needed because Anki doesn't place the image at correct location if a dialog shows up during `convert_mime` (see #28).