### PR TITLE
Fix NameError: name 'config' is not defined

### DIFF
--- a/media_converter/common.py
+++ b/media_converter/common.py
@@ -77,6 +77,7 @@ def find_convertible_audio(html: str, include_converted: bool = False) -> Iterab
 
 def tooltip(msg: str, parent: Optional[QWidget] = None) -> None:
     from aqt.utils import tooltip as _tooltip
+    from .config import config
 
     return _tooltip(msg=msg, period=config.tooltip_duration_seconds * 1000, parent=parent)
 
@@ -86,6 +87,8 @@ def filesize_kib(filepath: str) -> float:
 
 
 def image_html(image_filename: str) -> str:
+    from .config import config
+    
     return f'<img alt="{config.image_format.name} image" src="{image_filename}">'
 
 
@@ -105,6 +108,8 @@ def key_to_str(shortcut: str) -> str:
 
 
 def maybe_show_settings(dimensions: ImageDimensions, parent: Optional[QWidget], action: ShowOptions) -> int:
+    from .config import config
+
     if config.should_show_settings(action):
         dlg = AnkiPasteImageDialog(config=config, dimensions=dimensions, parent=parent)
         return dlg.exec()


### PR DESCRIPTION
I was getting the following error in Anki. I made the minimal changes that I thought would fix it.


```
Anki 25.02 (038d85b1)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: Windows-10-10.0.26100

Traceback (most recent call last):
  File "aqt.webview", line 53, in cmd
  File "aqt.webview", line 169, in _onCmd
  File "aqt.webview", line 728, in _onBridgeCmd
  File "decorator", line 232, in fun
  File "anki.hooks", line 92, in decorator_wrapper
  File "anki.hooks", line 87, in repl
  File "aqt.editor", line 513, in onBridgeCmd
  File "aqt.editor", line 1061, in onPaste
  File "aqt.editor", line 1550, in onPaste
  File "aqt.editor", line 1545, in _onPaste
  File "aqt.editor", line 1599, in _processMime
  File "_aqt.hooks", line 2824, in __call__
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1151815987\events.py", line 65, in on_process_mime
    return convert_mime(mime, editor_web_view.editor, action=ShowOptions.paste)
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1151815987\events.py", line 36, in convert_mime
    new_file_path = conv.convert_mime(to_convert)
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1151815987\file_converters\on_paste_converter.py", line 90, in convert_mime
    self._maybe_show_settings(to_convert.dimensions)
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1151815987\file_converters\on_paste_converter.py", line 73, in _maybe_show_settings
    result = maybe_show_settings(dimensions, parent=self._editor.parentWindow, action=self._action)
  File "C:\Users\Michael\AppData\Roaming\Anki2\addons21\1151815987\common.py", line 108, in maybe_show_settings
    if config.should_show_settings(action):
NameError: name 'config' is not defined

===Add-ons (active)===
(add-on provided name [Add-on folder, installed at, version, is config changed])
AJT Browser Play Button ['182970692', 2025-03-07T12:14, 'None', '']
AJT Media Converter  WebP AVIF Opus ['1151815987', 2025-03-19T19:00, 'None', mod]
AnkiConnect ['2055492159', 2025-02-25T14:57, 'None', '']
Chinese Support 3 ['1752008591', 2024-02-25T01:37, 'None', mod]
Clear all fields ['261351307', 2023-12-23T03:05, 'None', '']
OpenInExternalEditorRenameDuplicate for ImageAudioVideo WinLinux ['1560623518', 2023-03-19T10:33, 'None', mod]
Reviewer Context Menu Search ['359618071', 2019-02-10T09:01, 'None', '']

===IDs of active AnkiWeb add-ons===
1151815987 1560623518 1752008591 182970692 2055492159 261351307 359618071

===Add-ons (inactive)===
(add-on provided name [Add-on folder, installed at, version, is config changed])

```