### PR TITLE
feat: Use ThreadPoolExecutor for parallel conversion.

### DIFF
--- a/media_converter/bulk_convert/convert_result.py
+++ b/media_converter/bulk_convert/convert_result.py
@@ -1,10 +1,7 @@
 # Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-from __future__ import annotations
 
 from typing import Optional
-
-import threading
 
 from ..file_converters.common import LocalFile
 
@@ -13,15 +10,12 @@ class ConvertResult:
     def __init__(self) -> None:
         self._converted: dict[LocalFile, str] = {}
         self._failed: dict[LocalFile, Optional[Exception]] = {}
-        self._lock = threading.Lock()
 
     def add_converted(self, old_file: LocalFile, new_filename: str) -> None:
-        with self._lock:
-            self._converted[old_file] = new_filename
+        self._converted[old_file] = new_filename
 
     def add_failed(self, file: LocalFile, exception: Optional[Exception] = None):
-        with self._lock:
-            self._failed[file] = exception
+        self._failed[file] = exception
 
     @property
     def converted(self) -> dict[LocalFile, str]:
@@ -31,5 +25,5 @@ class ConvertResult:
     def failed(self) -> dict[LocalFile, Optional[Exception]]:
         return self._failed
 
-    def is_dirty(self) -> bool:
+    def has_results(self) -> bool:
         return bool(self._converted or self._failed)

--- a/media_converter/bulk_convert/convert_result.py
+++ b/media_converter/bulk_convert/convert_result.py
@@ -1,6 +1,10 @@
 # Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+from __future__ import annotations
+
 from typing import Optional
+
+import threading
 
 from ..file_converters.common import LocalFile
 
@@ -9,12 +13,15 @@ class ConvertResult:
     def __init__(self) -> None:
         self._converted: dict[LocalFile, str] = {}
         self._failed: dict[LocalFile, Optional[Exception]] = {}
+        self._lock = threading.Lock()
 
     def add_converted(self, old_file: LocalFile, new_filename: str) -> None:
-        self._converted[old_file] = new_filename
+        with self._lock:
+            self._converted[old_file] = new_filename
 
     def add_failed(self, file: LocalFile, exception: Optional[Exception] = None):
-        self._failed[file] = exception
+        with self._lock:
+            self._failed[file] = exception
 
     @property
     def converted(self) -> dict[LocalFile, str]:

--- a/media_converter/bulk_convert/convert_task.py
+++ b/media_converter/bulk_convert/convert_task.py
@@ -1,7 +1,10 @@
 # Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 import collections
+import os
+import concurrent.futures
 from collections.abc import Iterable, Sequence
+from typing import Optional
 
 from anki.collection import Collection
 from anki.notes import Note, NoteId
@@ -23,28 +26,71 @@ class ConvertTask:
     _selected_fields: list[str]
     _result: ConvertResult
     _to_convert: dict[LocalFile, dict[NoteId, Note]]
+    canceled: bool
 
     def __init__(self, browser: Browser, note_ids: Sequence[NoteId], selected_fields: list[str]):
         self._browser = browser
         self._selected_fields = selected_fields
         self._result = ConvertResult()
         self._to_convert = self._find_files_to_convert_and_notes(note_ids)
+        self.canceled = False
 
     @property
     def size(self) -> int:
         return len(self._to_convert)
 
+    def set_canceled(self) -> None:
+        self.canceled = True
+
     def __call__(self):
+        """
+        Execute the conversion using ThreadPoolExecutor for parallelism while reporting progress.
+        The conversion is performed in parallel; the order of completion is not guaranteed.
+        If the task is canceled, all pending jobs are cancelled and no further
+        conversions are started.  Running conversions are allowed to finish but
+        their results are ignored.
+        """
         if self._result.is_dirty():
             raise RuntimeError("Already converted.")
-        for progress_idx, file in enumerate(self._to_convert):
-            yield progress_idx
+        files = list(self._to_convert.keys())
+        max_workers = os.cpu_count() // 2 or 1
+
+        def convert_file(file: LocalFile) -> tuple[LocalFile, Optional[str], Optional[Exception]]:
+            """
+            Convert a single file.  Returns a tuple of (file, new_filename, exception).
+            If the task has been canceled, returns (file, None, None) immediately.
+            """
+            if self.canceled:
+                return (file, None, None)
             try:
                 converted_filename = self._convert_stored_file(file)
-            except (OSError, RuntimeError, FileNotFoundError) as ex:
-                self._result.add_failed(file, exception=ex)
-            else:
-                self._result.add_converted(file, converted_filename)
+                return (file, converted_filename, None)
+            except Exception as ex:
+                return (file, None, ex)
+
+        completed = 0
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_file = {executor.submit(convert_file, f): f for f in files}
+            for future in concurrent.futures.as_completed(future_to_file):
+                if self.canceled:
+                    # Cancel all remaining futures that have not started yet
+                    for f in future_to_file:
+                        if not f.done():
+                            f.cancel()
+                    break
+                file = future_to_file[future]
+                try:
+                    f, converted, exc = future.result()
+                except Exception as ex:
+                    # This should not happen because convert_file catches all exceptions
+                    exc = ex
+                    converted = None
+                if exc:
+                    self._result.add_failed(file, exception=exc)
+                elif converted is not None:
+                    self._result.add_converted(file, converted)
+                completed += 1
+                yield completed
 
     def update_notes(self):
         def show_report_message() -> int:
@@ -94,6 +140,14 @@ class ConvertTask:
         return to_convert
 
     def _convert_stored_file(self, file: LocalFile) -> str:
+        """
+        Convert a single file.  If the task has been canceled, the conversion
+        is skipped and a dummy filename is returned.  This allows the worker
+        threads to exit quickly without performing any work.
+        """
+        if self.canceled:
+            # Return the original filename to avoid changing the note
+            return file.file_name
         conv = InternalFileConverter(self._browser.editor, file, self._first_referenced(file))
         conv.convert_internal()
         return conv.new_filename

--- a/media_converter/bulk_convert/convert_task.py
+++ b/media_converter/bulk_convert/convert_task.py
@@ -65,11 +65,9 @@ class ConvertTask:
         if self._result.has_results():
             raise RuntimeError("Already converted.")
 
-        progress_idx = 0
-
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             future_to_file = {executor.submit(self._convert_stored_file, file): file for file in self._to_convert}
-            for future in concurrent.futures.as_completed(future_to_file):
+            for progress_idx, future in enumerate(concurrent.futures.as_completed(future_to_file), start=1):
                 if self._canceled:
                     cancel_all_remaining_futures(future_to_file)
                     break
@@ -82,7 +80,6 @@ class ConvertTask:
                     self._result.add_failed(original_filename, exception=ex)
                 else:
                     self._result.add_converted(original_filename, converted_filename)
-                progress_idx += 1
                 yield progress_idx
 
     def update_notes(self) -> None:

--- a/media_converter/bulk_convert/runnable.py
+++ b/media_converter/bulk_convert/runnable.py
@@ -25,6 +25,7 @@ class ConvertRunnable(QRunnable):
         self.task.set_canceled()
 
     def run(self) -> None:
+        self.signals.update_progress.emit(0)
         for progress_value in self.task():
             self.signals.update_progress.emit(progress_value)  # type: ignore
         self.signals.task_done.emit()  # type: ignore

--- a/media_converter/bulk_convert/runnable.py
+++ b/media_converter/bulk_convert/runnable.py
@@ -25,6 +25,7 @@ class ConvertRunnable(QRunnable):
 
     def set_canceled(self):
         self.canceled = True
+        self.task.set_canceled()
 
     def run(self):
         for progress_value in self.task():

--- a/media_converter/bulk_convert/runnable.py
+++ b/media_converter/bulk_convert/runnable.py
@@ -14,22 +14,17 @@ class ConvertSignals(QObject):
 
 
 class ConvertRunnable(QRunnable):
-    canceled: bool
 
-    def __init__(self, task: ConvertTask, signals: ConvertSignals):
+    def __init__(self, task: ConvertTask, signals: ConvertSignals) -> None:
         super().__init__()
-        self.canceled = False
         self.task = task
         self.signals = signals
         qconnect(self.signals.canceled, self.set_canceled)
 
-    def set_canceled(self):
-        self.canceled = True
+    def set_canceled(self) -> None:
         self.task.set_canceled()
 
-    def run(self):
+    def run(self) -> None:
         for progress_value in self.task():
-            if self.canceled:
-                break
             self.signals.update_progress.emit(progress_value)  # type: ignore
         self.signals.task_done.emit()  # type: ignore

--- a/media_converter/dialogs/bulk_convert_progress_bar.py
+++ b/media_converter/dialogs/bulk_convert_progress_bar.py
@@ -23,7 +23,7 @@ class ProgressBar(AnkiSaveAndRestoreGeomDialog):
         self.task = task
         self.signals = ConvertSignals()
         self.pool = QThreadPool.globalInstance()
-        cast(QWidget, self).setWindowTitle("Converting...")
+        self.setWindowTitle("Converting...")
         self.setMinimumSize(320, 24)
         self.move(100, 100)
         self.set_range(0, task.size)


### PR DESCRIPTION
Make conversion thread-safe and concurrent with cancel support.

This commit was generated with AI assistance. Please let me know if any changes should be made.