### PR TITLE
fix: macOS Finder copy pastes Finder icon instead of actual image

### DIFF
--- a/media_converter/consts.py
+++ b/media_converter/consts.py
@@ -2,6 +2,7 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import os
+import sys
 
 from .ajt_common.consts import ADDON_SERIES
 
@@ -18,3 +19,5 @@ REQUEST_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; Anki)"}
 REQUEST_TIMEOUTS = (3.05, 12.05)
 
 assert os.path.isdir(SUPPORT_DIR), "support dir must exist."
+IS_MAC = sys.platform.startswith("darwin")
+IS_WIN = sys.platform.startswith("win32")

--- a/media_converter/file_converters/common.py
+++ b/media_converter/file_converters/common.py
@@ -4,12 +4,11 @@ import enum
 import functools
 import os
 import subprocess
-import sys
 import typing
 from typing import Any
 
-IS_MAC = sys.platform.startswith("darwin")
-IS_WIN = sys.platform.startswith("win32")
+from ..consts import IS_WIN
+
 COMMON_AUDIO_FORMATS = frozenset(
     (".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a", ".aiff", ".amr", ".ape", ".mp2", ".oga", ".oma", ".opus")
 )

--- a/media_converter/file_converters/image_converter.py
+++ b/media_converter/file_converters/image_converter.py
@@ -9,12 +9,10 @@ from aqt.utils import showWarning
 
 from ..ajt_common.utils import find_executable as find_executable_ajt
 from ..config import ImageFormat, MediaConverterConfig
-from ..consts import ADDON_FULL_NAME, SUPPORT_DIR
+from ..consts import ADDON_FULL_NAME, IS_MAC, IS_WIN, SUPPORT_DIR
 from ..utils.mime_helper import iter_files
 from ..utils.show_options import ImageDimensions
 from .common import (
-    IS_MAC,
-    IS_WIN,
     ConverterType,
     create_process,
     get_file_extension,

--- a/media_converter/file_converters/internal_file_converter.py
+++ b/media_converter/file_converters/internal_file_converter.py
@@ -28,7 +28,9 @@ class InternalFileConverter:
     _converter: FileConverter
     _config: MediaConverterConfig
 
-    def __init__(self, editor: aqt.editor.Editor | None, file: LocalFile, note: Note, config: MediaConverterConfig) -> None:
+    def __init__(
+        self, editor: aqt.editor.Editor | None, file: LocalFile, note: Note, config: MediaConverterConfig
+    ) -> None:
         self._config = config
         self._conversion_finished = False
         self._initial_file_path = os.path.join(self._dest_dir, file.file_name)

--- a/media_converter/file_converters/on_add_note_converter.py
+++ b/media_converter/file_converters/on_add_note_converter.py
@@ -27,9 +27,7 @@ class OnAddNoteConverter:
     _config: MediaConverterConfig
     _finder: FindMedia
 
-    def __init__(
-        self, note: Note, action: ShowOptions, parent: QWidget | None, config: MediaConverterConfig
-    ) -> None:
+    def __init__(self, note: Note, action: ShowOptions, parent: QWidget | None, config: MediaConverterConfig) -> None:
         self._settings_shown = False
         self._action = action
         self._note = note

--- a/media_converter/media_rename.py
+++ b/media_converter/media_rename.py
@@ -143,7 +143,9 @@ class MediaRenameDialog(QDialog):
 class AnkiMediaRenameDialog(MediaRenameDialog):
     """Rename dialog that performs the actual rename inside Anki."""
 
-    def __init__(self, editor: Editor, note: Note, filenames: list[str], cfg: MediaConverterConfig | None = None) -> None:
+    def __init__(
+        self, editor: Editor, note: Note, filenames: list[str], cfg: MediaConverterConfig | None = None
+    ) -> None:
         super().__init__(filenames, parent=editor.widget)
         self.editor = editor
         self.note = note

--- a/media_converter/utils/converter_interfaces.py
+++ b/media_converter/utils/converter_interfaces.py
@@ -1,8 +1,7 @@
 # Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from collections.abc import Iterable
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 
 class FileNamePatterns:

--- a/media_converter/utils/file_paths_factory.py
+++ b/media_converter/utils/file_paths_factory.py
@@ -8,9 +8,9 @@ import random
 import re
 import time
 import unicodedata
+from collections.abc import Callable
 from time import gmtime, strftime
 from typing import Optional
-from collections.abc import Callable
 
 from anki.notes import Note
 from anki.utils import html_to_text_line

--- a/media_converter/utils/mime_helper.py
+++ b/media_converter/utils/mime_helper.py
@@ -3,13 +3,12 @@
 
 import re
 from collections.abc import Iterable
-from typing import Optional
 
 import requests
 from aqt.qt import *
 from requests.exceptions import InvalidSchema, Timeout
 
-from ..consts import REQUEST_HEADERS, REQUEST_TIMEOUTS
+from ..consts import IS_MAC, REQUEST_HEADERS, REQUEST_TIMEOUTS
 
 
 def urls_from_html(html: str) -> list:
@@ -48,13 +47,22 @@ def image_from_file(filepath: str) -> QImage | None:
         return None
 
 
+def has_local_files(mime: QMimeData) -> bool:
+    """Return True if the clipboard contains at least one local file URL."""
+    return any(url.isLocalFile() for url in mime.urls())
+
+
 def image_candidates(mime: QMimeData) -> Iterable[QImage | None]:
-    files = list(iter_files(mime))
-    if not files:
+    # On macOS, copying a file in Finder puts the file's .icns thumbnail on the clipboard.
+    # Qt exposes it as imageData() ('application/x-qt-image') and does not reveal the raw 'public.icns' UTI,
+    # so the thumbnail is indistinguishable from a genuine image by format alone.
+    # The reliable signature of a Finder copy is a local file URL alongside image data.
+    # Skip imageData(), but only on macOS, so genuine image payloads keep working everywhere else.
+    if not (IS_MAC and has_local_files(mime)):
         yield mime.imageData()
     for data in data_from_html(mime.html()):
         yield QImage.fromData(data)
-    for file in files:
+    for file in iter_files(mime):
         yield image_from_file(file)
     for url in iter_urls(mime):
         yield image_from_url(url)

--- a/media_converter/utils/mime_helper.py
+++ b/media_converter/utils/mime_helper.py
@@ -49,10 +49,12 @@ def image_from_file(filepath: str) -> QImage | None:
 
 
 def image_candidates(mime: QMimeData) -> Iterable[QImage | None]:
-    yield mime.imageData()
+    files = list(iter_files(mime))
+    if not files:
+        yield mime.imageData()
     for data in data_from_html(mime.html()):
         yield QImage.fromData(data)
-    for file in iter_files(mime):
+    for file in files:
         yield image_from_file(file)
     for url in iter_urls(mime):
         yield image_from_url(url)

--- a/media_converter/utils/temp_file.py
+++ b/media_converter/utils/temp_file.py
@@ -1,8 +1,8 @@
 # Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 import os
-from types import TracebackType
 from tempfile import mkstemp
+from types import TracebackType
 
 
 class TempFileException(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,6 @@ def no_anki_config() -> NoAnkiConfigView:
 
 
 @pytest.fixture(autouse=True, scope="function")
-def no_anki_config_mp(no_anki_config, monkeypatch):
+def no_anki_config_mp(no_anki_config, monkeypatch) -> NoAnkiConfigView:
     monkeypatch.setattr(media_converter.config, "get_global_config", lambda: no_anki_config, raising=False)
     return no_anki_config

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,7 +25,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 """
 
 
-def test_image_format():
+def test_image_format() -> None:
     assert frozenset(SUPPORTED_IMAGE_FORMATS) == frozenset(["avif", "webp"])
 
 

--- a/tests/test_mime_helper.py
+++ b/tests/test_mime_helper.py
@@ -1,0 +1,103 @@
+# Copyright: Ajatt-Tools and contributors; https://github.com/Ajatt-Tools
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import pathlib
+
+import pytest
+from aqt.qt import QImage, QMimeData, Qt, QUrl
+
+from media_converter.utils import mime_helper
+from media_converter.utils.mime_helper import (
+    has_local_files,
+    image_candidates,
+    image_from_file,
+)
+
+
+def write_valid_png(path: pathlib.Path) -> None:
+    """Write a tiny valid PNG via Qt itself."""
+    image = QImage(2, 2, QImage.Format.Format_ARGB32)
+    image.fill(Qt.GlobalColor.red)
+    assert image.save(str(path))
+
+
+class TestHasLocalFiles:
+    """Tests for has_local_files()."""
+
+    @pytest.mark.parametrize(
+        "urls, expected",
+        [
+            ([QUrl.fromLocalFile("/tmp/a.png")], True),
+            ([QUrl("https://example.com/a.png")], False),
+            ([QUrl.fromLocalFile("/tmp/a.png"), QUrl("https://example.com/b.png")], True),
+            ([], False),
+        ],
+        ids=["local_file", "remote_only", "mixed", "empty"],
+    )
+    def test_urls(self, urls: list[QUrl], expected: bool) -> None:
+        mime = QMimeData()
+        mime.setUrls(urls)
+        assert has_local_files(mime) == expected
+
+
+class TestImageCandidates:
+    """Tests for the macOS icns gating in image_candidates()."""
+
+    @pytest.mark.parametrize(
+        "is_mac, with_local_file, expect_file_image",
+        [
+            # Finder copy on macOS: imageData() (icns thumbnail) is skipped, file is read.
+            (True, True, True),
+            # Preview copy on macOS: no local file, imageData() is yielded (empty here).
+            (True, False, False),
+            # Other platforms: imageData() is yielded first even with a local file present.
+            (False, True, False),
+        ],
+        ids=["mac_finder_skips_image_data", "mac_no_file_keeps_image_data", "other_os_keeps_image_data"],
+    )
+    def test_image_data_gating(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: pathlib.Path,
+        is_mac: bool,
+        with_local_file: bool,
+        expect_file_image: bool,
+    ) -> None:
+        monkeypatch.setattr(mime_helper, "IS_MAC", is_mac)
+        mime = QMimeData()
+        if with_local_file:
+            png_path = tmp_path / "real.png"
+            write_valid_png(png_path)
+            mime.setUrls([QUrl.fromLocalFile(str(png_path))])
+        first = next(image_candidates(mime))
+        # When imageData() is skipped, the first candidate is the image read from the file.
+        # When imageData() is yielded, it is None because this QMimeData carries no image payload.
+        if expect_file_image:
+            assert isinstance(first, QImage)
+            assert not first.isNull()
+        else:
+            assert not isinstance(first, QImage) or first.isNull()
+
+
+class TestImageFromFile:
+    """Tests for image_from_file()."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [None, b"this is not an image"],
+        ids=["missing_file", "garbage_bytes"],
+    )
+    def test_unusable_file_yields_no_image(self, tmp_path: pathlib.Path, content: bytes | None) -> None:
+        path = tmp_path / "image.png"
+        if content is not None:
+            path.write_bytes(content)
+        result = image_from_file(str(path))
+        # Missing file -> None; undecodable bytes -> null QImage. Either way, no usable image.
+        assert result is None or result.isNull()
+
+    def test_valid_png(self, tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "valid.png"
+        write_valid_png(path)
+        result = image_from_file(str(path))
+        assert result is not None
+        assert not result.isNull()


### PR DESCRIPTION
**NOTE: I am a novice at coding. I did the troubleshooting and created this PR with Claude. It's a small change. Kindly proceed with caution.**

## Problem
On macOS, copying a file in Finder (Cmd+C) and pasting into Anki 
produces a valid but wrong WebP — it converts the Finder thumbnail 
icon instead of the actual image file.

## Root cause
When a file is copied in Finder, macOS puts multiple formats on the 
clipboard including `«class icns»` (the Finder thumbnail/icon) and 
`«class furl»` (the file path). Qt's `mime.imageData()` successfully 
decodes the `icns` icon data and returns it — so `image_candidates()` 
yields the icon before ever reaching `image_from_file()`, which would 
have read the actual image correctly.

Confirmed via `osascript -e 'clipboard info'`:
- Finder copy: leads with `«class furl»` and `«class icns»`
- Preview copy (works correctly): leads with `«class PNGf»`, no file reference

## Fix
Skip `mime.imageData()` when local files are present on the clipboard. 
In that case, read directly from the file path instead.

## Tested on
- macOS Sequoia, Apple M4
- Anki Version ⁨26.05 (e64c6b1a)⁩ | Python 3.13.11 Qt 6.11.0 Chromium 140
- AJT Media Converter v26.7.19.0